### PR TITLE
Wait for translations to be loaded from proxy in SET_LANGUAGE

### DIFF
--- a/src/store/module/actions.js
+++ b/src/store/module/actions.js
@@ -82,8 +82,8 @@ export default {
     }
 
     // use the proxy to dynamically retrieve the translation
-    proxy.getTranslation(lang).then((response) => {
-      dispatch(events.SET_TRANSLATION, {
+    return proxy.getTranslation(lang).then((response) => {
+      return dispatch(events.SET_TRANSLATION, {
         translation: response,
         code: lang.code
       })


### PR DESCRIPTION
Return the promise that getTranslation returns to make sure that
initI18nManager also waits for translations to be loaded from the
proxy.

Fixes #37 